### PR TITLE
Fix CDE nesting issue

### DIFF
--- a/theme/apps/dictionary/scripts/dictionary-views.js
+++ b/theme/apps/dictionary/scripts/dictionary-views.js
@@ -314,7 +314,7 @@
             property = dictionaryProperties[propertyName],
             description = _.get(property, 'term.description', false) || _.get(property, 'description', false) || _.get(dictionaryTerms, propertyName + '.description', 'n/a'),
             valueOrType = _getPropertyValueOrType(property),
-            CDE = _.get(dictionaryTerms, propertyName + '.common.termDef.cde_id'),
+            CDE = _.get(dictionaryTerms, propertyName + '.common.termDef'),
             isRequired = requiredProperties && requiredProperties.indexOf(propertyName) >= 0 ? 'Yes' : 'No';
 
         // Ignore system properties for now...

--- a/theme/apps/dictionary/scripts/dictionary-views.js
+++ b/theme/apps/dictionary/scripts/dictionary-views.js
@@ -314,7 +314,7 @@
             property = dictionaryProperties[propertyName],
             description = _.get(property, 'term.description', false) || _.get(property, 'description', false) || _.get(dictionaryTerms, propertyName + '.description', 'n/a'),
             valueOrType = _getPropertyValueOrType(property),
-            CDE = _.get(dictionaryTerms, propertyName + '.termDef'),
+            CDE = _.get(dictionaryTerms, propertyName + '.common.termDef.cde_id'),
             isRequired = requiredProperties && requiredProperties.indexOf(propertyName) >= 0 ? 'Yes' : 'No';
 
         // Ignore system properties for now...

--- a/theme/apps/dictionary/scripts/dictionary-views.js
+++ b/theme/apps/dictionary/scripts/dictionary-views.js
@@ -314,7 +314,8 @@
             property = dictionaryProperties[propertyName],
             description = _.get(property, 'term.description', false) || _.get(property, 'description', false) || _.get(dictionaryTerms, propertyName + '.description', 'n/a'),
             valueOrType = _getPropertyValueOrType(property),
-            CDE = _.get(dictionaryTerms, propertyName + '.common.termDef'),
+            CDE = _.get(dictionaryTerms, [propertyName + '.node.property.termDef', propertyName + '.common.termDef']) ||
+              _.get(dictionaryTerms, propertyName + '.common.termDef'),
             isRequired = requiredProperties && requiredProperties.indexOf(propertyName) >= 0 ? 'Yes' : 'No';
 
         // Ignore system properties for now...

--- a/theme/apps/dictionary/scripts/dictionary-views.js
+++ b/theme/apps/dictionary/scripts/dictionary-views.js
@@ -314,7 +314,7 @@
             property = dictionaryProperties[propertyName],
             description = _.get(property, 'term.description', false) || _.get(property, 'description', false) || _.get(dictionaryTerms, propertyName + '.description', 'n/a'),
             valueOrType = _getPropertyValueOrType(property),
-            CDE = _.get(dictionaryTerms, [propertyName + '.node.property.termDef', propertyName + '.common.termDef']) ||
+            CDE = _.get(dictionaryTerms, propertyName + '.node.property.termDef') ||
               _.get(dictionaryTerms, propertyName + '.common.termDef'),
             isRequired = requiredProperties && requiredProperties.indexOf(propertyName) >= 0 ? 'Yes' : 'No';
 


### PR DESCRIPTION
`termDef.cde_id` is now nested under `common` (or `node.property` in the future)