### PR TITLE
Add HHS Vulnerability Disclosure link to footer

### DIFF
--- a/theme/404.html
+++ b/theme/404.html
@@ -125,6 +125,7 @@
                             | <a href="http://www.cancer.gov/global/web/policies" target="_blank">Policies</a>
                             | <a href="http://www.cancer.gov/global/web/policies/accessibility" target="_blank">Accessibility</a>
                             | <a href="http://www.cancer.gov/global/web/policies/foia" target="_blank">FOIA</a>
+                            | <a href="https://www.hhs.gov/vulnerability-disclosure-policy" target="_blank">HHS Vulnerability Disclosure</a>
                         </div>
                         <div>
                             <a href="http://www.hhs.gov" target="_blank">U.S. Department of Health and Human Services</a>

--- a/theme/base.html
+++ b/theme/base.html
@@ -149,6 +149,7 @@
                             | <a href="http://www.cancer.gov/global/web/policies" target="_blank">Policies</a>
                             | <a href="http://www.cancer.gov/global/web/policies/accessibility" target="_blank">Accessibility</a>
                             | <a href="http://www.cancer.gov/global/web/policies/foia" target="_blank">FOIA</a>
+                            | <a href="https://www.hhs.gov/vulnerability-disclosure-policy" target="_blank">HHS Vulnerability Disclosure</a>
                         </div>
                         <div>
                             <a href="http://www.hhs.gov" target="_blank">U.S. Department of Health and Human Services</a>


### PR DESCRIPTION
Adds HHS Vulnerability Discocluse Link:
Old:
![image](https://user-images.githubusercontent.com/1093780/173913498-f7c127c1-23b9-4052-8bf6-fa2312213bef.png)
New
```
Site Home | Policies | Accessibility | FOIA | HHS Vulnerability Disclosure
```
See https://jira.opensciencedatacloud.org/browse/PEAR-249