### PR TITLE
bugfix: Downgrade Markdown

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ mkdocs==0.15.1
 mkdocs-bootstrap==0.1.1
 mkdocs-bootswatch==0.4
 BSCodeTabs
-Markdown==2.6.11
+Markdown==2.6.7
 MarkupSafe==1.0


### PR DESCRIPTION
Downgrading Markdown dependency as a bug introduced in newer versions breaks the deployment