### PR TITLE
PEAR-2162 - Add NCI OCPL Government Shutdown Banner to GDC Documentation Site

### DIFF
--- a/docs/js/analytics-after-load.js
+++ b/docs/js/analytics-after-load.js
@@ -1,1 +1,0 @@
-_satellite.pageBottom();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,8 +19,6 @@ extra_css:
   - stylesheets/gdc-common.css
   - stylesheets/homepage.css
   - stylesheets/font-awesome-4.5.css
-extra_javascript:
-  - js/analytics-after-load.js
 markdown_extensions:
   - tables
   - pymdownx.superfences

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -1,9 +1,5 @@
 {% extends "base.html" %}
 
-{% block extrahead %}
-<script src="https://assets.adobedtm.com/6a4249cd0a2c/785de09de161/launch-70d67a6a40a8.min.js" async></script
-{% endblock %}
-
 {% set site_title = "NCI Genomic Data Commons (GDC)" %}
 {% set page_title = "Documentation" %}
 {% set page_subtitle = "A place where researchers, data submitters and developers can find detailed information on GDC processes and tools." %}

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block extrahead %}
+<script src="https://assets.adobedtm.com/6a4249cd0a2c/785de09de161/launch-70d67a6a40a8.min.js" async></script
+{% endblock %}
+
 {% set site_title = "NCI Genomic Data Commons (GDC)" %}
 {% set page_title = "Documentation" %}
 {% set page_subtitle = "A place where researchers, data submitters and developers can find detailed information on GDC processes and tools." %}

--- a/overrides/partials/integrations/analytics/custom.html
+++ b/overrides/partials/integrations/analytics/custom.html
@@ -1,1 +1,1 @@
-<script src="https://assets.adobedtm.com/6a4249cd0a2c/073fd0859f8f/launch-39d47c17b228.min.js"></script>
+<script src="https://assets.adobedtm.com/6a4249cd0a2c/785de09de161/launch-70d67a6a40a8.min.js" async></script>


### PR DESCRIPTION
Adds the script specified in the ticket. Wasn't able to get the banner actually to show up in my development environment so not sure if more steps are needed?