### PR TITLE
PEAR-2163 - Doc site improvements round 2

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2024-09-11T18:16:30Z",
+  "version": "1.4.0",
   "plugins_used": [
     {
-      "name": "AWSKeyDetector"
+      "name": "ArtifactoryDetector"
     },
     {
-      "name": "ArtifactoryDetector"
+      "name": "AWSKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -31,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -51,6 +51,46 @@
     },
     {
       "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
   "results": {
@@ -130,7 +170,7 @@
         "filename": "docs/API/Users_Guide/Submission.md",
         "hashed_secret": "93f5b94e262e685fee4a419438d60e82fafaf491",
         "is_verified": false,
-        "line_number": 1225,
+        "line_number": 1205,
         "is_secret": false
       },
       {
@@ -333,41 +373,5 @@
       }
     ]
   },
-  "version": "1.4.0",
-  "filters_used": [
-    {
-      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_lock_file"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_swagger_file"
-    }
-  ]
+  "generated_at": "2024-09-19T19:16:13Z"
 }

--- a/docs/API/Users_Guide/Appendix_A_Available_Fields.md
+++ b/docs/API/Users_Guide/Appendix_A_Available_Fields.md
@@ -2119,7 +2119,7 @@ The GDC API's [search and retrieval endpoints](Search_and_Retrieval.md) provide 
 | project.program |
 
 ### GDC Conventions Supplemental
-| Field Group Name |
+| Field Group Name | |
 | --- | --- |
 | File size | Listed in bytes |
 | Submitter id | String supplied by submitter |

--- a/docs/API/Users_Guide/Submission.md
+++ b/docs/API/Users_Guide/Submission.md
@@ -1269,11 +1269,11 @@ The PATCH method cannot be used to create new entities, and the provided submitt
 
 === "Command1"
 
-  ```shell
-  token=$(<gdc-token-text-file.txt)
+    ```shell
+    token=$(<gdc-token-text-file.txt)
 
-  curl --header "X-Auth-Token: $token" --request POST --data-binary @Request --header 'Content-Type: application/json' https://api.gdc.cancer.gov/v0/submission/GDC/INTERNAL
-  ```
+    curl --header "X-Auth-Token: $token" --request POST --data-binary @Request --header 'Content-Type: application/json' https://api.gdc.cancer.gov/v0/submission/GDC/INTERNAL
+    ```
 
 === "Response1"
 
@@ -1319,16 +1319,16 @@ The PATCH method cannot be used to create new entities, and the provided submitt
 
 === "Request2"
 
-  ```json
-  {
-    "type": "demographic",
-    "submitter_id": "demographic7892",
-    "cause_of_death": "Infection", 
-    "cause_of_death_source": "Death Certificate", 
-    "country_of_birth": "Antigua and Barbuda", 
-    "country_of_residence_at_enrollment": "Antigua and Barbuda"
-  }
-  ```
+    ```json
+    {
+      "type": "demographic",
+      "submitter_id": "demographic7892",
+      "cause_of_death": "Infection",
+      "cause_of_death_source": "Death Certificate",
+      "country_of_birth": "Antigua and Barbuda",
+      "country_of_residence_at_enrollment": "Antigua and Barbuda"
+    }
+    ```
 
 === "Command2"
 
@@ -1338,7 +1338,7 @@ The PATCH method cannot be used to create new entities, and the provided submitt
     curl --header "X-Auth-Token: $token" --request PATCH --data-binary @Request --header 'Content-Type: application/json' https://api.gdc.cancer.gov/v0/submission/GDC/INTERNAL
     ```
 
-"Response2"
+=== "Response2"
 
     ```json
     {

--- a/docs/Data_Dictionary/viewer/dictionary.css
+++ b/docs/Data_Dictionary/viewer/dictionary.css
@@ -404,7 +404,6 @@ a.dictionary-anchor {
 
 .monospace {
   font-family: monospace;
-  font-size: 12px;
 }
 
 .dropdown-menu.show {

--- a/docs/Encyclopedia/pages/TCGA_VCF_1.1v2.md
+++ b/docs/Encyclopedia/pages/TCGA_VCF_1.1v2.md
@@ -107,7 +107,7 @@ sample-specific metadata.
 
 All TCGA-specific additions and modifications in [validation
 steps](#validation-rules) are prefixed with a
-<TCGA-VCF> tag for convenient comparison with 1000Genomes VCF 4.1. The
+<TCGA-VCF\> tag for convenient comparison with 1000Genomes VCF 4.1. The
 following table summarizes TCGA-specific customizations that have been added to
 the VCF 4.1 specification. The first column, "Customization type", indicates
 whether a new validation step has been introduced or if an existing step has
@@ -184,7 +184,7 @@ indicate whether a given variant exists in dbSNP).
 
 ### Generic meta-information
 
-**Format**: *##key=value* OR *##FIELDTYPE=<key1=value1,key2=value2,...>*
+**Format**: *##key=value* OR *##FIELDTYPE=<key1=value1,key2=value2,...\>*
 
 The following table lists some of the reserved field names. Files can be
 customized to contain additional meta-information fields as long as they are not
@@ -234,7 +234,7 @@ is mandatory and lists the VCF version number of the file.
 
 ### INFO/FORMAT/FILTER meta-information
 
-**Format**: *##FIELDTYPE=<key1=value1,key2=value2,...>*
+**Format**: *##FIELDTYPE=<key1=value1,key2=value2,...\>*
 
 INFO, FORMAT and FILTER (case-sensitive values) are optional fields that have to
 be declared in the HEADER if they are being referred to in BODY of the file.
@@ -245,7 +245,7 @@ definitions for further details.
 **Important**: TCGA VCF 1.1 requires all VCF files to follow consistent header
 declarations for standard INFO and FORMAT sub-fields. Please refer to Tables 4
 and 5 for details. If a sub-field exists in these tables and is used in a TCGA
-VCF file, then all <key=value> pairs in the definition should match entries in
+VCF file, then all <key=value\> pairs in the definition should match entries in
 the corresponding table for the file to pass validation.
 
 **Table 3: Description of keys used in INFO/FORMAT/FILTER meta-information
@@ -264,7 +264,7 @@ declarations**
 
 #### INFO lines
 
-**Format**: *##INFO=<key1=value1,key2=value2,...>*  
+**Format**: *##INFO=<key1=value1,key2=value2,..\.>*
 **Required keys**: ID, Type, Number, Description
 
 INFO fields are optional and contain additional annotations for a variant.
@@ -286,7 +286,7 @@ following format:
 
 #### FORMAT lines
 
-**Format**: *##FORMAT=<key1=value1,key2=value2,...>*  
+**Format**: *##FORMAT=<key1=value1,key2=value2,...\>*
 **Required keys**: ID, Type, Number, Description
 
 FORMAT declaration lines are used when annotations need to be added for
@@ -327,7 +327,7 @@ value.
 
 #### FILTER lines
 
-**Format**: *##FILTER=<key1=value1,key2=value2,...>*  
+**Format**: *##FILTER=<key1=value1,key2=value2,...\>* 
 **Required keys**: ID, Description
 
 FILTER fields are defined to list filtering criteria used for generating variant
@@ -358,78 +358,78 @@ given field is interpreted the same way across all centers and that same
 
 | **Sub-field** | **Source** | **Formatted declaration**                                                                                                                                                                           |
 |---------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| AA            | VCF        | ##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">                                                                                                                              |
-| AC            | VCF        | ##INFO=<ID=AC,Number=.,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">                                                                  |
-| AF            | VCF        | ##INFO=<ID=AF,Number=.,Type=Float,Description="Allele Frequency in primary data, for each ALT allele, in the same order as listed">                                                             |
-| AN            | VCF        | ##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">                                                                                                  |
-| BQ            | VCF        | ##INFO=<ID=BQ,Number=1,Type=Integer,Description="RMS base quality">                                                                                                                             |
-| CIGAR         | VCF        | ##INFO=<ID=CIGAR,Number=1,Type=Integer,Description="Cigar string describing how to align an alternate allele to the reference allele">                                                          |
-| DB            | VCF        | ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership">                                                                                                                                |
-| DP            | VCF        | ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth across samples">                                                                                                                   |
-| END           | VCF        | ##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">                                                                                        |
-| H2            | VCF        | ##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">                                                                                                                              |
-| H3            | VCF        | ##INFO=<ID=H3,Number=0,Type=Flag,Description="HapMap3 membership">                                                                                                                              |
-| MQ            | VCF        | ##INFO=<ID=MQ,Number=1,Type=Integer,Description="RMS Mapping Quality">                                                                                                                          |
-| MQ0           | VCF        | ##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads">                                                                                                            |
-| NS            | VCF        | ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">                                                                                                                  |
-| SB            | VCF        | ##INFO=<ID=SB,Number=1,Type=Float,Description="Strand bias">                                                                                                                                    |
-| SOMATIC       | VCF        | ##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description="Indicates if record is a somatic mutation">                                                                                                  |
-| VALIDATED     | VCF        | ##INFO=<ID=VALIDATED,Number=0,Type=Flag,Description="Indicates if variant has been validated by follow-up experiment">                                                                          |
-| 1000G         | VCF        | ##INFO=<ID=1000G,Number=0,Type=Flag,Description="Indicates membership in 1000Genomes">                                                                                                          |
-| IMPRECISE     | VCF        | ##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Imprecise structural variation">                                                                                                           |
-| NOVEL         | VCF        | ##INFO=<ID=NOVEL,Number=0,Type=Flag,Description="Indicates a novel structural variation">                                                                                                       |
-| SVTYPE        | VCF        | ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">                                                                                                                |
-| SVLEN         | VCF        | ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">                                                                                          |
-| CIPOS         | VCF        | ##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS for imprecise variants">                                                                                     |
-| CIEND         | VCF        | ##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END for imprecise variants">                                                                                     |
-| HOMLEN        | VCF        | ##INFO=<ID=HOMLEN,Number=.,Type=Integer,Description="Length of base pair identical micro-homology at event breakpoints">                                                                        |
-| HOMSEQ        | VCF        | ##INFO=<ID=HOMSEQ,Number=.,Type=String,Description="Sequence of base pair identical micro-homology at event breakpoints">                                                                       |
-| BKPTID        | VCF        | ##INFO=<ID=BKPTID,Number=.,Type=String,Description="ID of the assembled alternate allele in the assembly file">                                                                                 |
-| MEINFO        | VCF        | ##INFO=<ID=MEINFO,Number=4,Type=String,Description="Mobile element info of the form NAME,START,END,POLARITY">                                                                                   |
-| METRANS       | VCF        | ##INFO=<ID=METRANS,Number=4,Type=String,Description="Mobile element transduction info of the form CHR,START,END,POLARITY">                                                                      |
-| DGVID         | VCF        | ##INFO=<ID=DGVID,Number=1,Type=String,Description="ID of this element in Database of Genomic Variation">                                                                                        |
-| DBVARID       | VCF        | ##INFO=<ID=DBVARID,Number=1,Type=String,Description="ID of this element in DBVAR"\]>                                                                                                              |
-| DBRIPID       | VCF        | ##INFO=<ID=DBRIPID,Number=1,Type=String,Description="ID of this element in DBRIP">                                                                                                              |
-| MATEID        | VCF        | ##INFO=<ID=MATEID,Number=.,Type=String,Description="ID of mate breakends">                                                                                                                      |
-| PARID         | VCF        | ##INFO=<ID=PARID,Number=1,Type=String,Description="ID of partner breakend">                                                                                                                     |
-| EVENT         | VCF        | ##INFO=<ID=EVENT,Number=1,Type=String,Description="ID of event associated to breakend">                                                                                                         |
-| CILEN         | VCF        | ##INFO=<ID=CILEN,Number=2,Type=Integer,Description="Confidence interval around the length of the inserted material between breakends">                                                          |
-| DPADJ         | VCF        | ##INFO=<ID=DPADJ,Number=.,Type=Integer,Description="Read Depth of adjacency">                                                                                                                   |
-| CN            | VCF        | ##INFO=<ID=CN,Number=1,Type=Integer,Description="Copy number of segment containing breakend">                                                                                                   |
-| CNADJ         | VCF        | ##INFO=<ID=CNADJ,Number=.,Type=Integer,Description="Copy number of adjacency">                                                                                                                  |
-| CICN          | VCF        | ##INFO=<ID=CICN,Number=2,Type=Integer,Description="Confidence interval around copy number for the segment">                                                                                     |
-| CICNADJ       | VCF        | ##INFO=<ID=CICNADJ,Number=.,Type=Integer,Description="Confidence interval around copy number for the adjacency">                                                                                |
-| VLS           | TCGA-VCF   | ##INFO=<ID=VLS,Number=1,Type=Integer,Description="Final validation status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post transcriptional modification,5=unknown"> |
-| SID           | TCGA-VCF   | ##INFO=<ID=SID,Number=.,Type=String,Description="Unique identifier from gene annotation source or unknown">                                                                                     |
-| GENE          | TCGA-VCF   | ##INFO=<ID=GENE,Number=.,Type=String,Description="HUGO gene symbol or Unknown">                                                                                                                 |
-| RGN           | TCGA-VCF   | ##INFO=<ID=RGN,Number=.,Type=String,Description="Region where nucleotide variant occurs in relation to a gene">                                                                                 |
-| RE            | TCGA-VCF   | ##INFO=<ID=RE,Number=0,Type=Flag,Description="Position known to have RNA-edits to occur">                                                                                                       |
-| VT            | TCGA-VCF   | ##INFO=<ID=VT,Number=1,Type=String,Description="Variant type, can be SNP, INS or DEL">                                                                                                          |
+| AA            | VCF        | ##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele"\>                                                                                                                              |
+| AC            | VCF        | ##INFO=<ID=AC,Number=.,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed"\>                                                                  |
+| AF            | VCF        | ##INFO=<ID=AF,Number=.,Type=Float,Description="Allele Frequency in primary data, for each ALT allele, in the same order as listed"\>                                                             |
+| AN            | VCF        | ##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes"\>                                                                                                  |
+| BQ            | VCF        | ##INFO=<ID=BQ,Number=1,Type=Integer,Description="RMS base quality"\>                                                                                                                             |
+| CIGAR         | VCF        | ##INFO=<ID=CIGAR,Number=1,Type=Integer,Description="Cigar string describing how to align an alternate allele to the reference allele"\>                                                          |
+| DB            | VCF        | ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership"\>                                                                                                                                |
+| DP            | VCF        | ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth across samples"\>                                                                                                                   |
+| END           | VCF        | ##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record"\>                                                                                        |
+| H2            | VCF        | ##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership"\>                                                                                                                              |
+| H3            | VCF        | ##INFO=<ID=H3,Number=0,Type=Flag,Description="HapMap3 membership"\>                                                                                                                              |
+| MQ            | VCF        | ##INFO=<ID=MQ,Number=1,Type=Integer,Description="RMS Mapping Quality"\>                                                                                                                          |
+| MQ0           | VCF        | ##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total Mapping Quality Zero Reads"\>                                                                                                            |
+| NS            | VCF        | ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data"\>                                                                                                                  |
+| SB            | VCF        | ##INFO=<ID=SB,Number=1,Type=Float,Description="Strand bias"\>                                                                                                                                    |
+| SOMATIC       | VCF        | ##INFO=<ID=SOMATIC,Number=0,Type=Flag,Description="Indicates if record is a somatic mutation"\>                                                                                                  |
+| VALIDATED     | VCF        | ##INFO=<ID=VALIDATED,Number=0,Type=Flag,Description="Indicates if variant has been validated by follow-up experiment"\>                                                                          |
+| 1000G         | VCF        | ##INFO=<ID=1000G,Number=0,Type=Flag,Description="Indicates membership in 1000Genomes"\>                                                                                                          |
+| IMPRECISE     | VCF        | ##INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Imprecise structural variation"\>                                                                                                           |
+| NOVEL         | VCF        | ##INFO=<ID=NOVEL,Number=0,Type=Flag,Description="Indicates a novel structural variation"\>                                                                                                       |
+| SVTYPE        | VCF        | ##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant"\>                                                                                                                |
+| SVLEN         | VCF        | ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles"\>                                                                                          |
+| CIPOS         | VCF        | ##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS for imprecise variants"\>                                                                                     |
+| CIEND         | VCF        | ##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END for imprecise variants"\>                                                                                     |
+| HOMLEN        | VCF        | ##INFO=<ID=HOMLEN,Number=.,Type=Integer,Description="Length of base pair identical micro-homology at event breakpoints"\>                                                                        |
+| HOMSEQ        | VCF        | ##INFO=<ID=HOMSEQ,Number=.,Type=String,Description="Sequence of base pair identical micro-homology at event breakpoints"\>                                                                       |
+| BKPTID        | VCF        | ##INFO=<ID=BKPTID,Number=.,Type=String,Description="ID of the assembled alternate allele in the assembly file"\>                                                                                 |
+| MEINFO        | VCF        | ##INFO=<ID=MEINFO,Number=4,Type=String,Description="Mobile element info of the form NAME,START,END,POLARITY"\>                                                                                   |
+| METRANS       | VCF        | ##INFO=<ID=METRANS,Number=4,Type=String,Description="Mobile element transduction info of the form CHR,START,END,POLARITY"\>                                                                      |
+| DGVID         | VCF        | ##INFO=<ID=DGVID,Number=1,Type=String,Description="ID of this element in Database of Genomic Variation"\>                                                                                        |
+| DBVARID       | VCF        | ##INFO=<ID=DBVARID,Number=1,Type=String,Description="ID of this element in DBVAR"\]\>                                                                                                              |
+| DBRIPID       | VCF        | ##INFO=<ID=DBRIPID,Number=1,Type=String,Description="ID of this element in DBRIP"\>                                                                                                              |
+| MATEID        | VCF        | ##INFO=<ID=MATEID,Number=.,Type=String,Description="ID of mate breakends"\>                                                                                                                      |
+| PARID         | VCF        | ##INFO=<ID=PARID,Number=1,Type=String,Description="ID of partner breakend"\>                                                                                                                     |
+| EVENT         | VCF        | ##INFO=<ID=EVENT,Number=1,Type=String,Description="ID of event associated to breakend"\>                                                                                                         |
+| CILEN         | VCF        | ##INFO=<ID=CILEN,Number=2,Type=Integer,Description="Confidence interval around the length of the inserted material between breakends"\>                                                          |
+| DPADJ         | VCF        | ##INFO=<ID=DPADJ,Number=.,Type=Integer,Description="Read Depth of adjacency"\>                                                                                                                   |
+| CN            | VCF        | ##INFO=<ID=CN,Number=1,Type=Integer,Description="Copy number of segment containing breakend"\>                                                                                                   |
+| CNADJ         | VCF        | ##INFO=<ID=CNADJ,Number=.,Type=Integer,Description="Copy number of adjacency"\>                                                                                                                  |
+| CICN          | VCF        | ##INFO=<ID=CICN,Number=2,Type=Integer,Description="Confidence interval around copy number for the segment"\>                                                                                     |
+| CICNADJ       | VCF        | ##INFO=<ID=CICNADJ,Number=.,Type=Integer,Description="Confidence interval around copy number for the adjacency"\>                                                                                |
+| VLS           | TCGA-VCF   | ##INFO=<ID=VLS,Number=1,Type=Integer,Description="Final validation status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post transcriptional modification,5=unknown"\> |
+| SID           | TCGA-VCF   | ##INFO=<ID=SID,Number=.,Type=String,Description="Unique identifier from gene annotation source or unknown"\>                                                                                     |
+| GENE          | TCGA-VCF   | ##INFO=<ID=GENE,Number=.,Type=String,Description="HUGO gene symbol or Unknown"\>                                                                                                                 |
+| RGN           | TCGA-VCF   | ##INFO=<ID=RGN,Number=.,Type=String,Description="Region where nucleotide variant occurs in relation to a gene"\>                                                                                 |
+| RE            | TCGA-VCF   | ##INFO=<ID=RE,Number=0,Type=Flag,Description="Position known to have RNA-edits to occur"\>                                                                                                       |
+| VT            | TCGA-VCF   | ##INFO=<ID=VT,Number=1,Type=String,Description="Variant type, can be SNP, INS or DEL"\>                                                                                                          |
 
 ##### Table 5: FORMAT sub-field definitions
 
 | **Sub-field** | **Source** | **Formatted declaration**                                                                                                                                                                   |
 |---------------|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| GT            | VCF        | ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">                                                                                                                            |
-| DP            | VCF        | ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth at this position in the sample">                                                                                          |
-| FT            | VCF        | ##FORMAT=<ID=FT,Number=1,Type=String,Description="Sample genotype filter">                                                                                                              |
-| GL            | VCF        | ##FORMAT=<ID=GL,Number=.,Type=Float,Description="Genotype likelihoods">                                                                                                                 |
-| PL            | VCF        | ##FORMAT=<ID=PL,Number=3,Type=Integer,Description="Normalized, Phred-scaled likelihoods for AA,AB,BB genotypes where A=ref and B=alt; not applicable if site is not biallelic">         |
-| GP            | VCF        | ##FORMAT=<ID=GP,Number=.,Type=Float,Description="Phred-scaled genotype posterior probabilities">                                                                                        |
-| GQ            | VCF        | ##FORMAT=<ID=GQ,Number=.,Type=Integer,Description="Conditional Phred-scaled genotype quality">                                                                                          |
-| HQ            | VCF        | ##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype qualities, two comma separated phred qualities">                                                                           |
-| CN            | VCF        | ##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Copy number genotype for imprecise events">                                                                                          |
-| CNQ           | VCF        | ##FORMAT=<ID=CNQ,Number=1,Type=Float,Description="Copy number genotype quality for imprecise events">                                                                                   |
-| CNL           | VCF        | ##FORMAT=<ID=CNL,Number=.,Type=Float,Description="Copy number genotype likelihood for imprecise events">                                                                                |
-| MQ            | VCF        | ##FORMAT=<ID=MQ,Number=1,Type=Integer,Description="Phred style probability score that the variant is novel with respect to the genome's ancestor">                                      |
-| HAP           | VCF        | ##FORMAT=<ID=HAP,Number=1,Type=Integer,Description="Unique haplotype identifier">                                                                                                       |
-| AHAP          | VCF        | ##FORMAT=<ID=AHAP,Number=1,Type=Integer,Description="Unique identifier of ancestral haplotype">                                                                                         |
-| SS            | TCGA-VCF   | ##FORMAT=<ID=SS,Number=1,Type=Integer,Description="Variant status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post-transcriptional modification,5=unknown"> |
-| TE            | TCGA-VCF   | ##FORMAT=<ID=TE,Number=.,Type=String,Description="Translational effect of the variant in a codon">                                                                                      |
-| AD            | TCGA-VCF   | ##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Depth of reads supporting alleles 0/1/2/3...">                                                                                       |
-| DP4           | TCGA-VCF   | ##FORMAT=<ID=DP4,Number=4,Type=Integer,Description="Number of high-quality ref-forward, ref-reverse, alt-forward and alt-reverse bases">                                                |
-| BQ            | TCGA-VCF   | ##FORMAT=<ID=BQ,Number=.,Type=Integer,Description="Average base quality for reads supporting alleles">                                                                                  |
-| VAQ           | TCGA-VCF   | ##FORMAT=<ID=VAQ,Number=1,Type=Integer,Description="Variant allele quality">                                                                                                            |
+| GT            | VCF        | ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype"\>                                                                                                                            |
+| DP            | VCF        | ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read depth at this position in the sample"\>                                                                                          |
+| FT            | VCF        | ##FORMAT=<ID=FT,Number=1,Type=String,Description="Sample genotype filter"\>                                                                                                              |
+| GL            | VCF        | ##FORMAT=<ID=GL,Number=.,Type=Float,Description="Genotype likelihoods"\>                                                                                                                 |
+| PL            | VCF        | ##FORMAT=<ID=PL,Number=3,Type=Integer,Description="Normalized, Phred-scaled likelihoods for AA,AB,BB genotypes where A=ref and B=alt; not applicable if site is not biallelic"\>         |
+| GP            | VCF        | ##FORMAT=<ID=GP,Number=.,Type=Float,Description="Phred-scaled genotype posterior probabilities"\>                                                                                        |
+| GQ            | VCF        | ##FORMAT=<ID=GQ,Number=.,Type=Integer,Description="Conditional Phred-scaled genotype quality"\>                                                                                          |
+| HQ            | VCF        | ##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype qualities, two comma separated phred qualities"\>                                                                           |
+| CN            | VCF        | ##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Copy number genotype for imprecise events"\>                                                                                          |
+| CNQ           | VCF        | ##FORMAT=<ID=CNQ,Number=1,Type=Float,Description="Copy number genotype quality for imprecise events"\>                                                                                   |
+| CNL           | VCF        | ##FORMAT=<ID=CNL,Number=.,Type=Float,Description="Copy number genotype likelihood for imprecise events"\>                                                                                |
+| MQ            | VCF        | ##FORMAT=<ID=MQ,Number=1,Type=Integer,Description="Phred style probability score that the variant is novel with respect to the genome's ancestor"\>                                      |
+| HAP           | VCF        | ##FORMAT=<ID=HAP,Number=1,Type=Integer,Description="Unique haplotype identifier"\>                                                                                                       |
+| AHAP          | VCF        | ##FORMAT=<ID=AHAP,Number=1,Type=Integer,Description="Unique identifier of ancestral haplotype"\>                                                                                         |
+| SS            | TCGA-VCF   | ##FORMAT=<ID=SS,Number=1,Type=Integer,Description="Variant status relative to non-adjacent Normal,0=wildtype,1=germline,2=somatic,3=LOH,4=post-transcriptional modification,5=unknown"\> |
+| TE            | TCGA-VCF   | ##FORMAT=<ID=TE,Number=.,Type=String,Description="Translational effect of the variant in a codon"\>                                                                                      |
+| AD            | TCGA-VCF   | ##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Depth of reads supporting alleles 0/1/2/3..."\>                                                                                       |
+| DP4           | TCGA-VCF   | ##FORMAT=<ID=DP4,Number=4,Type=Integer,Description="Number of high-quality ref-forward, ref-reverse, alt-forward and alt-reverse bases"\>                                                |
+| BQ            | TCGA-VCF   | ##FORMAT=<ID=BQ,Number=.,Type=Integer,Description="Average base quality for reads supporting alleles"\>                                                                                  |
+| VAQ           | TCGA-VCF   | ##FORMAT=<ID=VAQ,Number=1,Type=Integer,Description="Variant allele quality"\>                                                                                                            |
 
 
 
@@ -439,7 +439,7 @@ given field is interpreted the same way across all centers and that same
 
 #### PEDIGREE lines
 
-**Format**: *##PEDIGREE=<key1=value1,key2=value2,...>*  
+**Format**: *##PEDIGREE=<key1=value1,key2=value2,...\>*
 **Required keys**: Name_0,..,Name_N where N \>= 1;
 
 PEDIGREE lines are used to specify derivation relationships between different
@@ -458,7 +458,7 @@ example below, PRIMARY-TUMOR-GENOME is derived from GERMLINE-GENOME.
 
 #### SAMPLE lines
 
-**Format**: *##SAMPLE=<key1=value1,key2=value2,...>*  
+**Format**: *##SAMPLE=<key1=value1,key2=value2,...\>* 
 **Required keys**: ID, SampleName, Individual, File, Platform, Source, Accession
 
 For UUID-compliant files, following rules should be followed:
@@ -494,14 +494,14 @@ and 'Genome_Description" tags represent comma-separated list of different
 genomes that a sample contains, proportion of each genome in the sample, and a
 brief description of each genome respectively.
 
-##SAMPLE=<ID=id,SampleName=sampleName,Individual=individual,Description="description",
-File=bamfile,Platform=platformName,Source=source,Accession=acc,Genomes=<G1-ID,G2-ID,..,GK-ID>,Mixture=
-<N1,N2,..,NK>,Genome_Description=<"S1","S2",..,"SK">>
+\#\#SAMPLE=<ID=id,SampleName=sampleName,Individual=individual,Description="description",
+File=bamfile,Platform=platformName,Source=source,Accession=acc,Genomes=<G1-ID,G2-ID,..,GK-ID\>,Mixture=
+<N1,N2,..,NK\>,Genome_Description=<"S1","S2",..,"SK">>
 
 Example:
 
-##SAMPLE=<ID=NORMAL,SampleName=TCGA-06-0881-10A-01W,Individual=TCGA-06-0881,Description="Normal",File=TCGA-06-0881-10A-01W-0421-09.bam,Platform=Illumina,Source=dbGAP,Accession=1234,Genomes=<Germline,Tumor>,Mixture=<0.1,0.9>,Genome_Description=<"Germline
-contamination","Tumor genome">>
+\#\#SAMPLE=<ID=NORMAL,SampleName=TCGA-06-0881-10A-01W,Individual=TCGA-06-0881,Description="Normal",File=TCGA-06-0881-10A-01W-0421-09.bam,Platform=Illumina,Source=dbGAP,Accession=1234,Genomes=<Germline,Tumor\>,Mixture=<0.1,0.9>,Genome_Description=<"Germline
+contamination","Tumor genome"\>>
 
 -   "Description" field for genome mixture has been renamed to
     "Genome_Description" to distinguish it from sample description.
@@ -518,8 +518,8 @@ This is a mandatory header line where the first 8 fields are fixed and have to
 defined in the column header. "FORMAT" onwards are optional and are included to
 encapsulate per-sample/genome genotype data.
 
-#CHROM POS ID REF ALT QUAL FILTER INFO FORMAT <SAMPLE1 or GENOME1> <SAMPLE2
-or GENOME2> ...
+\#CHROM POS ID REF ALT QUAL FILTER INFO FORMAT <SAMPLE1 or GENOME1\> <SAMPLE2
+or GENOME2\> ...
 
 BODY
 ### Variant records
@@ -537,13 +537,13 @@ are optional.
 | **Index** | **Field**  | **Case-sensitive** | **Description** | **Data type** | **Sample values**     | **Required\*** | **Additional notes** |
 | --------- | ---------- | ------------------ | --------------- | ------------- | --------------------- | -------------- | -------------------- |
 | 1         | CHROM      | Yes                                                                        | *Chromosome*: an identifier from the reference genome or the assembly file defined in the HEADER                                                                                                                                                                                                                             | Alphanumeric string                                                                      | 20                    | Yes            | Chromosome name should not contain "chr" prefix, e.g., "chr10" will be an invalid entry                                                                                                                                                                                                                                                                                                                                                                              |
-|           |            |                                                                            |                                                                                                                                                                                                                                                                                                                              | *([1-22], X, Y, MT, <ID>)*                                                             | <ctg1>              |                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|           |            |                                                                            |                                                                                                                                                                                                                                                                                                                              | *([1-22], X, Y, MT, <ID\>)*                                                             | <ctg1>              |                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | 2         | POS        | Yes                                                                        | *Position*: The reference position, with the 1st base having position 1                                                                                                                                                                                                                                                      | Non-negative integer                                                                     | 1110696               | Yes            | \---                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | 3         | ID         | Yes                                                                        | *Identifier*: Semi-colon separated list of unique identifiers if available                                                                                                                                                                                                                                                   | String, no white-space or semi-colons                                                    | rs6054257_66370       | No             | **Important**: When using an rsID as the variant identifier, please append chromosomal location of the variant to the ID. For example, if the variant is at chr7:6013153 and the corresponding rsID is rs10000, then the variant ID should be rs10000_6013153. This is to ensure that there is a consistent rule for satisfying the condition for unique IDs even if a file contains single rsID that maps to multiple variants                                      |
 | 4         | REF        | Yes                                                                        | *Reference allele(s)*: Reference allele at the position                                                                                                                                                                                                                                                                      | String                                                                                   | GTCT                  | Yes            | Value in POS field refers to the position of the first base in the REF string                                                                                                                                                                                                                                                                                                                                                                                        |
 |           |            |                                                                            |                                                                                                                                                                                                                                                                                                                              | *([ACGTN]+* )                                                                            |                       |                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | 5         | ALT        | Yes                                                                        | *Alternate allele(s)*: Comma separated list of alternate non-reference alleles called on at least one of the samples. Angle-bracketed ID String (\<ID\>) can also be used for symbolically representing alternate alleles                                                                                                  | String; no whitespace, commas, or angle-brackets in the ID string                        | G,GTCT                | No             | if ALT==<ID>, ID needs to be defined in the header as                                                                                                                                                                                                                                                                                                                                                                                                              |
-|           |            |                                                                            |                                                                                                                                                                                                                                                                                                                              | *([ACGTN]+, <ID>, .)*                                                                  | .                     |                | ##ALT=<ID=*Id*,Description=*"description"*>                                                                                                                                                                                                                                                                                                                                                                                                                      |
+|           |            |                                                                            |                                                                                                                                                                                                                                                                                                                              | *([ACGTN]+, <ID\>, .)*                                                                  | .                     |                | ##ALT=<ID=*Id*,Description=*"description"*>                                                                                                                                                                                                                                                                                                                                                                                                                      |
 |           |            |                                                                            |                                                                                                                                                                                                                                                                                                                              |                                                                                          | <INS:ME:ALU>        |                |                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | 6         | QUAL       | Yes                                                                        | *Quality score*: Phred-scaled quality score for the assertion made in ALT                                                                                                                                                                                                                                                    | Integer \>= 0                                                                            | 50                    | No             | Scores should be non-negative integers or missing values                                                                                                                                                                                                                                                                                                                                                                                                             |
 | 7         | FILTER     | Yes                                                                        | *Filtering results*: PASS if this position has passed all filters, Otherwise, if the site has not passed all filters, a semicolon-separated list of codes for filters that fail                                                                                                                                              | String, no whitespace or semi-colon                                                      | PASS                  | No             | "0" is reserved and cannot be used as a filter String                                                                                                                                                                                                                                                                                                                                                                                                                |
@@ -720,40 +720,40 @@ Line3 ##fileDate=20120205
 
 Line4 ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
 
-Line5 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+Line5 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype"\>
 
-Line6 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+Line6 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality"\>
 
 Line7 ##FORMAT=<ID=SS,Number=1,Type=Integer,Description="Variant status
 relative to non-adjacent Normal,
-0=wildtype,1=germline,2=somatic,3=LOH,4=unknown">
+0=wildtype,1=germline,2=somatic,3=LOH,4=unknown"\>
 
 Line8 ##INFO=<ID=VLS,Number=1,Type=Integer,Description="Final validation
 status relative to non-adjacent Normal,
-0=wildtype,1=germline,2=somatic,3=LOH,4=unknown">
+0=wildtype,1=germline,2=somatic,3=LOH,4=unknown"\>
 
-Line9 ##FILTER=<ID=q10,Description="Quality below 10">
+Line9 ##FILTER=<ID=q10,Description="Quality below 10"\>
 
 Line10
-##SAMPLE=<ID=NORMAL,SampleName=TCGA-06-0881-10A-01W,Individual=TCGA-06-0881,Description="Normal",File=TCGA-06-0881-10A-01W-0421-09_illumina.bam,Platform=Illumina,Source=dbGAP,Accession=1234>
+\#\#SAMPLE=<ID=NORMAL,SampleName=TCGA-06-0881-10A-01W,Individual=TCGA-06-0881,Description="Normal",File=TCGA-06-0881-10A-01W-0421-09_illumina.bam,Platform=Illumina,Source=dbGAP,Accession=1234\>
 
 Line11
-##SAMPLE=<ID=NORMAL_454,SampleName=TCGA-06-0881-10A-01W,Individual=TCGA-06-0881,Description="Validation
+\#\#SAMPLE=<ID=NORMAL_454,SampleName=TCGA-06-0881-10A-01W,Individual=TCGA-06-0881,Description="Validation
 normal sample tested with
-454",File=TCGA-06-0881-10A-01W-0421-09_454.bam,Platform=454,Source=dbGAP,Accession=245>
+454",File=TCGA-06-0881-10A-01W-0421-09_454.bam,Platform=454,Source=dbGAP,Accession=245\>
 
 Line12
-##SAMPLE=<ID=TUMOR,SampleName=TCGA-06-0881-01A-01W,Individual=TCGA-06-0881,Description="Tumor",File=TCGA-06-0881-01A-01W-0421-09.bam,Platform=Illumina,Source=dbGAP,Accession=1234>
+\#\#SAMPLE=<ID=TUMOR,SampleName=TCGA-06-0881-01A-01W,Individual=TCGA-06-0881,Description="Tumor",File=TCGA-06-0881-01A-01W-0421-09.bam,Platform=Illumina,Source=dbGAP,Accession=1234\>
 
 Line13
-##SAMPLE=<ID=TUMOR_454,SampleName=TCGA-06-0881-01A-01W,Individual=TCGA-06-0881,Description="Validation
+\#\#SAMPLE=<ID=TUMOR_454,SampleName=TCGA-06-0881-01A-01W,Individual=TCGA-06-0881,Description="Validation
 tumor sample tested with
-454",File=TCGA-06-0881-01A-01W-0421-09_454.bam,Platform=454,Source=dbGAP,Accession=3456>
+454",File=TCGA-06-0881-01A-01W-0421-09_454.bam,Platform=454,Source=dbGAP,Accession=3456\>
 
 Line14
-##SAMPLE=<ID=TUMOR_Sanger,SampleName=TCGA-06-0881-01A-01W,Individual=TCGA-06-0881,Description="Validation
+\#\#SAMPLE=<ID=TUMOR_Sanger,SampleName=TCGA-06-0881-01A-01W,Individual=TCGA-06-0881,Description="Validation
 tumor sample tested with Sanger
-seq",File=.,Platform=Sanger_PCR,Source=.,Accession=.>
+seq",File=.,Platform=Sanger_PCR,Source=.,Accession=.\>
 
 Line15 #CHROM POS ID REF ALT QUAL FILTER INFO FORMAT NORMAL TUMOR NORMAL_454
 TUMOR_454 TUMOR_Sanger
@@ -838,24 +838,24 @@ Line4 ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
 Line5 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With
 Data">
 
-Line6 ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership">
+Line6 ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership"\>
 
-Line7 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+Line7 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype"\>
 
-Line8 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+Line8 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality"\>
 
-Line9 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+Line9 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth"\>
 
 Line10 ##FORMAT=<ID=PL,Number=3,Type=Integer,Description=" Normalized
-Phred-scaled likelihoods for AA, AB, BB genotypes ">
+Phred-scaled likelihoods for AA, AB, BB genotypes "\>
 
-Line11 ##FILTER=<ID=q10,Description="Quality below 10">
+Line11 ##FILTER=<ID=q10,Description="Quality below 10"\>
 
-Line12 ##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+Line12 ##FILTER=<ID=s50,Description="Less than 50% of samples have data"\>
 
-Line13 FILTER=<ID=c10,Description="Shallow coverage below 10x">
+Line13 FILTER=<ID=c10,Description="Shallow coverage below 10x"\>
 
-Line14 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
+Line14 ##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element"\>
 
 Line15 #CHROM POS ID REF ALT QUAL FILTER INFO FORMAT TCGA-02-0001-01
 TCGA-02-0001-02
@@ -873,7 +873,7 @@ Line20 9 13567 . A \<DUP\> 20 PASS NS=3 GT:GQ:PL 0/1:49:42,3 1/1:38:96,47/70
 Line21 3 18901 rs456 T C 15 PASS NS=3/DB GT 0/1 1/1
 
 **Important**: A file will be validated as a TCGA VCF file only if it contains
-##tcgaversion HEADER line (e.g., ##tcgaversion=1.1). The current acceptable
+\#\#tcgaversion HEADER line (e.g., \#\#tcgaversion=1.1). The current acceptable
 version is 1.1.
 
 1.  Mandatory [header lines](#TCGAVariantCallFormat(VCF)1.1Specificat) should be
@@ -898,11 +898,11 @@ version is 1.1.
     the format below where all keys are required but the order of keys is
     irrelevant.
 
-7.  ##INFO=<ID=id,Number=number,Type=type,Description="description">
+7.  \#\#INFO=<ID=id,Number=number,Type=type,Description="description"\>
 
-8.  ##FORMAT=<ID=id,Number=number,Type=type,Description="description">
+8.  \#\#FORMAT=<ID=id,Number=number,Type=type,Description="description"\>
 
-9.  ##FILTER=<ID=id,Description="description">
+9.  \#\#FILTER=<ID=id,Description="description"\>
 
 10. Values assigned to *ID, Number, Type* and *Description* in INFO, FORMAT or
     FILTER declarations should follow the rules listed below. A detailed
@@ -1061,7 +1061,7 @@ version is 1.1.
         declaration in the HEADER. Line18 shows a violation as "q10" does not
         have an associated definition in the HEADER.
 
-18. \<TCGA-VCF\> Validation of
+18. <TCGA-VCF\> Validation of
     [SAMPLE](#TCGAVariantCallFormat(VCF)1.1Specificat) meta-information lines:
 
     1.  Each sample ID in the column header (immediately after FORMAT column)
@@ -1095,12 +1095,12 @@ version is 1.1.
         barcode](https://docs.gdc.cancer.gov/Encyclopedia/pages/TCGA_Barcode/) / [UUID](https://docs.gdc.cancer.gov/Encyclopedia/pages/UUID/)
         in the database (TCGA VCF 1.1).
 
-19. <TCGA-VCF> Validation of
+19. <TCGA-VCF\> Validation of
     [PEDIGREE](#TCGAVariantCallFormat(VCF)1.1Specificat) meta-information lines:
 
     1.  Declaration line should follow the format:
 
-    2.  ##PEDIGREE=<Name_0=G0-ID,Name_1=G1-ID,...,Name_N=GN-ID>
+    2.  \#\#PEDIGREE=<Name_0=G0-ID,Name_1=G1-ID,...,Name_N=GN-ID\>
 
 >   where:
 
@@ -1117,6 +1117,7 @@ version is 1.1.
 -   The keys and values used in the <Name_N=Value_N> should be unique across
     assignments in any given PEDIGREE declaration.
 
+
 1.  Validation of custom meta-information fields:
 
     1.  If a user-created custom meta-information declaration is encountered and
@@ -1124,20 +1125,20 @@ version is 1.1.
         in this specification, the line should be validated to ensure it follows
         one of the following two formats:
 
-    2.  ##key=value
+    2.  \#\#key=value
 
     3.  Example:
 
-    4.  ##<INDIVIDUAL=TCGA-24-0980>
+    4.  \#\#<INDIVIDUAL=TCGA-24-0980\>
 
     5.  OR
 
-    6.  ##FIELDTYPE=<key1=value1,key2=value2,...>
+    6.  \#\#FIELDTYPE=<key1=value1,key2=value2,...\>
 
     7.  Example:
 
-    8.  ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo
-        sapiens",taxonomy=x>
+    8.  \#\#contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo
+        sapiens",taxonomy=x\>
 
 >   where:
 
@@ -1151,26 +1152,26 @@ version is 1.1.
     value identifiers. Please refer to [Table
     6](#TCGAVariantCallFormat(VCF)1.1Specificat) for acceptable values.
 
-    1.  <TCGA-VCF> *CHROM* is in {[1-22], X, Y, MT,<chr_ID>} where chr_ID
-        cannot contain whitespace or <>
+    1.  <TCGA-VCF\> *CHROM* is in {[1-22], X, Y, MT,<chr_ID\>} where chr_ID
+        cannot contain whitespace or <\>
 
-    2.  If CHROM == <chr_ID> then the VCF file MUST have a declaration for
+    2.  If CHROM == <chr_ID\> then the VCF file MUST have a declaration for
         assembly file in the HEADER. Please note that values assigned to the
         field are currently not being validated.
 
-    3.  ##assembly=url or filename
+    3.  \#\#assembly=url or filename
 
     4.  Example:
 
-    5.  ##assembly=ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/release/sv/breakpoint_assemblies.fasta
+    5.  \#\#assembly=ftp://ftp-trace.ncbi.nih.gov/1000genomes/ftp/release/sv/breakpoint_assemblies.fasta
 
-    6.  ##assembly=breakpoint_assemblies.fasta
+    6.  \#\#assembly=breakpoint_assemblies.fasta
 
     7.  *POS* is a non-negative integer
 
     8.  *REF* =\~ /[ACGTN]+/
 
-2.  <TCGA-VCF> *ALT* is in {[ACGTN]+, ".", <ID>, **SV_ALT**};
+2.  <TCGA-VCF\> *ALT* is in {[ACGTN]+, ".", <ID>, **SV_ALT**};
 
     1.  String SV_ALT can be in one of the following four formats and can be
         used in the *ALT*field ONLY when the corresponding INFO field has the
@@ -1194,15 +1195,15 @@ version is 1.1.
 
 -   *pos* is a non-negative integer
 
-1.  Similar to 18b, if chr == <chr_ID> (where *chr_ID* is a string) then the
+1.  Similar to 18b, if chr == <chr_ID\> (where *chr_ID* is a string) then the
     VCF file must have an ##assembly declaration in the HEADER.
 
-2.  If *ALT* is assigned a value in <ID> format, (e.g., rs123 in Line19),
+2.  If *ALT* is assigned a value in <ID\> format, (e.g., rs123 in Line19),
     <ID> should be defined in the HEADER as
-    ##ALT=<ID=*ID*,Description="*Description*"> (Line14) where ID cannot
+    ##ALT=<ID=*ID*,Description="*Description*"\> (Line14) where ID cannot
     contain white-space or angle brackets. Line20 shows a violation of this rule
-    as *ALT==*<DUP> but there is no corresponding *ALT* declaration in the
-    HEADER with <ID=DUP>.
+    as *ALT==*<DUP\> but there is no corresponding *ALT* declaration in the
+    HEADER with <ID=DUP\>.
 
 3.  ALT can contain multiple comma-separated values. No other character can be
     used as a separator.
@@ -1215,28 +1216,28 @@ version is 1.1.
 
 5.  *QUAL* field can only contain non-negative integers or "." (missing value).
 
-6.  <TCGA-VCF> If INFO sub-field "VT" is declared and used in the BODY, its
+6.  <TCGA-VCF\> If INFO sub-field "VT" is declared and used in the BODY, its
     value can only be in {SNP, INS, DEL}
 
-7.  <TCGA-VCF> If FORMAT sub-field "SS" is declared and used in the BODY, its
+7.  <TCGA-VCF\> If FORMAT sub-field "SS" is declared and used in the BODY, its
     value can be 0, 1, 2, 3, 4 or 5 depending on whether relative to normal the
     variant is wildtype, germline, somatic, LOH, post-transcriptional
     modification, or unknown respectively.
 
-8.  <TCGA-VCF> "DP" sub-field for read depth can be defined in INFO (combined
+8.  <TCGA-VCF\> "DP" sub-field for read depth can be defined in INFO (combined
     depth across all samples) or FORMAT (depth in a specific sample) field. If
     both INFO and FORMAT have values for the sub-field, then sum of DP values
     across all FORMAT sample columns should be equal to DP value in the INFO
     field.
 
-9.  <TCGA-VCF> Validation of **complex rearrangement** records:
+9.  <TCGA-VCF\> Validation of **complex rearrangement** records:
 
     1.  If INFO field includes key-value pairs "SVTYPE=BND" or "SVTYPE=FND" and
         has values for "MATEID" and/or "PARID", then the value (or multiple
         comma-separated values) assigned to MATEID or PARID should exist in the
         file as "ID" field for another variant record.
 
-10. <TCGA-VCF> Validation of RNA-Seq **annotation fields**:
+10. <TCGA-VCF\> Validation of RNA-Seq **annotation fields**:
 
     1.  If INFO field includes "SID", "GENE" or "RGN" keys with associated
         values, then file MUST contain a declaration for ##geneAnno in the
@@ -1256,18 +1257,18 @@ version is 1.1.
         would lead to a violation as the 2nd value for RGN is "intron" but the
         corresponding TE value is "SIL" instead of "NA".
 
-11. <TCGA-VCF> Validation of
+11. <TCGA-VCF\> Validation of
     [vcfProcessLog](#TCGAVariantCallFormat(VCF)1.1Specificat) tags:
 
-##vcfProcessLog=<InputVCF=<file1.vcf>,InputVCFSource=<varCaller1>,InputVCFVer=<1.0>,InputVCFParam=<a1,c2>,InputVCFgeneAnno=<anno1.gaf>>
+\#\#vcfProcessLog=<InputVCF=<file1.vcf\>,InputVCFSource=<varCaller1\>,InputVCFVer=<1.0>,InputVCFParam=<a1,c2\>,InputVCFgeneAnno=<anno1.gaf\>\>
 
 OR
 
-##vcfProcessLog=<InputVCF=<file1.vcf,file2.vcf,file3.vcf>,InputVCFSource=<varCaller1,varCaller2,varCaller3>,InputVCFVer=<1.0,2.1,2.0>,
+\#\#vcfProcessLog=<InputVCF=<file1.vcf,file2.vcf,file3.vcf\>,InputVCFSource=<varCaller1,varCaller2,varCaller3\>,InputVCFVer=<1.0,2.1,2.0>,
 
-InputVCFParam=<a1,c2;a1,b1;a1,b1>,InputVCFgeneAnno=<anno1.gaf,anno2.gaf,anno3.gaf>,
+InputVCFParam=<a1,c2;a1,b1;a1,b1\>,InputVCFgeneAnno=<anno1.gaf,anno2.gaf,anno3.gaf\>,
 
-MergeSoftware=<sw1,sw2>,MergeParam=<a1,a2;b1,b2>,MergeVer=<2.1,3.0>,MergeContact=<johndoe@xyz.edu>>
+MergeSoftware=<sw1,sw2\>,MergeParam=<a1,a2;b1,b2\>,MergeVer=<2.1,3.0>,MergeContact=<johndoe@xyz.edu\>\>
 
 1.  Individual values for each tag are enclosed within angle brackets (<>)
     instead of double quotes.

--- a/docs/stylesheets/gdc-common.css
+++ b/docs/stylesheets/gdc-common.css
@@ -1151,15 +1151,19 @@ footer {
     }
   }
 
-  .md-typeset iframe {
-    max-width: inherit;
-  }
+.md-typeset iframe {
+  max-width: inherit;
+}
 
-  .md-typeset pre>code {
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
+.md-typeset pre>code {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
 
-  .md-header__title {
-    visibility: hidden;
-  }
+.md-header__title {
+  visibility: hidden;
+}
+
+.md-header__button.md-logo img, .md-header__button.md-logo svg {
+    height: 1.8rem;
+}


### PR DESCRIPTION
Fixes for these:

- For Data Dictionary viewer pages, the font size for the Property and Acceptable Types and Values columns seem quite small compared to the other columns, such as the Description column (example: http://gdc-docs-dev.nci.nih.gov/Data_Dictionary/viewer/#?view=table-definition-view&id=demographic)
- “GDC Conventions Supplemental“ table at bottom of http://gdc-docs-dev.nci.nih.gov/API/Users_Guide/Appendix_A_Available_Fields/ not properly resolving
- The TCGA VCF encyclopedia entry has some messed up formatting starting around half way down. See screenshot.
- The NCI GDC Logo is rather small and the font size of the menu names is also small (See logo size in the original MVS Search image).