### PR TITLE
PEAR-2394 - TSV button non‑functional in Dictionary Viewer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -255,25 +255,9 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "docs/Data_Dictionary/viewer.md",
-        "hashed_secret": "bda4195ff28a812d14a7e4dd172299f68962d55a",
-        "is_verified": false,
-        "line_number": 10,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/Data_Dictionary/viewer.md",
         "hashed_secret": "406ff424dc0a82cba2f75fd2965c5862e89fc505",
         "is_verified": false,
-        "line_number": 12,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "docs/Data_Dictionary/viewer.md",
-        "hashed_secret": "04a52a012e416f2d2b07b144a16e757e36da7ecd",
-        "is_verified": false,
-        "line_number": 13,
+        "line_number": 11,
         "is_secret": false
       }
     ],
@@ -376,5 +360,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-06T21:01:04Z"
+  "generated_at": "2025-04-24T16:17:52Z"
 }

--- a/docs/Data_Dictionary/viewer.md
+++ b/docs/Data_Dictionary/viewer.md
@@ -7,10 +7,8 @@ hide:
 # Data Dictionary Viewer
 
 <link rel="stylesheet" href="dictionary.css">
-<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js" integrity="sha512-vc58qvvBdrDR4etbxMdlTt4GBQk1qjvyORR2nrsPsFPyrs+/u5c3+1Ct6upOgdZoIl7eq6k3a1UPDSNAQi/32A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
 <script src="dictionary-init.js"></script>
 <script src="dictionary.js"></script>


### PR DESCRIPTION
Two instances of bootstrap on this page were both firing, causing the dropdown to toggle closed -> open -> closed on every click. 

To answer the questions on the ticket:
1) this issue started after bootstrap was added to every page in https://github.com/NCI-GDC/gdc-docs/pull/439
2) TSV is the intended default download value
3) The dropdown on the main controls the format of these table level downloads: 
<img width="1412" alt="Screenshot 2025-04-24 at 11 41 10 AM" src="https://github.com/user-attachments/assets/5cf55b36-3f32-43f9-b5e3-3b20afd51385" />
 