### PR TITLE
DOC-499 add precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,11 @@ repos:
     hooks:
       - id: yamlfmt
         args: [--mapping, '2', --sequence, '4', --offset, '2', --width, '80']
+  - repo: https://github.com/sirosen/texthooks
+    rev: 0.6.8
+    hooks:
+      - id: fix-smartquotes
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: master
+    hooks:
+      - id: require-ascii


### PR DESCRIPTION
Added precommit hooks for detecting
- curly quotes
- unicode chars

Curly quotes in release notes:
<img width="388" alt="Screenshot 2025-07-01 at 4 28 04 PM" src="https://github.com/user-attachments/assets/075be00f-599e-4c11-99cd-a50b27929bd6" />

Curly quotes fixing:
<img width="617" alt="Screenshot 2025-07-01 at 4 28 47 PM" src="https://github.com/user-attachments/assets/60dc4984-c34c-43c7-bea8-22686863b829" />

Unicode in release notes:
<img width="348" alt="Screenshot 2025-07-01 at 4 31 04 PM" src="https://github.com/user-attachments/assets/593dc7c8-5338-427b-bd09-87b7aa4b232f" />

Unicode detection:
<img width="807" alt="Screenshot 2025-07-01 at 4 31 22 PM" src="https://github.com/user-attachments/assets/f3aef2b5-cf0d-42ca-8287-90cf9ecf0645" />
