### PR TITLE
Update Data_Dictionary_Release_Notes.md

### DIFF
--- a/docs/Data_Dictionary/Release_Notes/Data_Dictionary_Release_Notes.md
+++ b/docs/Data_Dictionary/Release_Notes/Data_Dictionary_Release_Notes.md
@@ -58,7 +58,9 @@
   	 	* New permissible value: `9478/3`
 		* New permissible value: `9490/6`
   	* Removed property: `metastasis_at_diagnosis_site`
+	* Removed property: `micropapillary_features`
   	* Removed property: `mitotic_count`
+	* Removed property: `papillary_renal_cell_type`
   	* Removed property: `pregnant_at_diagnosis`
   	* Removed property: `primary_disease`
 * Altered `family_history` Entity
@@ -236,8 +238,6 @@
 		* New permissible value: `After Study Registration`
     		* Deprecated value: `After Study Enrollment`
    		* Deprecated value: `Prior to Study Enrollment`
-	* Removed property: `micropapillary_features`
-	* Removed property: `papillary_renal_cell_type`
 * Altered `treatment` Entity
 	* Removed property: `treatment_anatomic_site`
 	* Removed property: `treatment_arm`

--- a/docs/Data_Dictionary/Release_Notes/Data_Dictionary_Release_Notes.md
+++ b/docs/Data_Dictionary/Release_Notes/Data_Dictionary_Release_Notes.md
@@ -49,9 +49,18 @@
 	* Changes made to `population_group`
 		* New permissible value: `Unknown`
 		* New permissible value: `Not Reported`
+* Altered `diagnosis` entity
+  	* Changes made to `morphology`
+		* New permissible value: `8453/6`
+		* New permissible value: `9380/1`
+  	 	* New permissible value: `9385/3`
+		* New permissible value: `9421/3`
+  	 	* New permissible value: `9478/3`
+		* New permissible value: `9490/6`
 * Altered `family_history` Entity
   	* Changes made to `deprecated`
-  	  	* Deprecated property: `relationship_sex_at_birth`
+  	  	* Deprecated property: `relationship_gender`
+  	* New property: `relationship_sex_at_birth`
 * Altered `other_clinical_attribute` Entity
 	* New property: `fertility_history`
 	* Removed property: `pregnancy_count`
@@ -123,13 +132,14 @@
 		* New permissible value: `Ventricular Tachycardia`
 	* Changes made to `timepoint_category`
 		* New permissible value: `After Study Registration`
+   		* Deprecated value: `After Study Enrollment`
+   		* Deprecated value: `Prior to Study Enrollment`
 * Altered `simple_somatic_mutation` Entity
 	* Changes made to `data_format`
 		* New permissible value: `TSV`
 	* Changes made to `data_type`
 		* New permissible value: `Mutational Signature`
 * Altered `follow_up` Entity
-	* Removed property: `deprecated`
 	* Removed property: `aids_risk_factors`
 	* Removed property: `bmi`
 	* Removed property: `body_surface_area`
@@ -175,9 +185,10 @@
 	* Removed property: `undescended_testis_history_laterality`
 	* Removed property: `viral_hepatitis_serologies`
 	* Removed property: `weight`
-	* Changes made to `days_to_first_event`
 	* Changes made to `timepoint_category`
 		* New permissible value: `After Study Registration`
+		* Deprecated value: `After Study Enrollment`
+   		* Deprecated value: `Prior to Study Enrollment`
 * Altered `read_group` Entity
 	* Changes made to `single_cell_library`
 		* New permissible value: `Chromium 3' Gene Expression v1 Library`
@@ -201,7 +212,6 @@
 * Altered `analyte` Entity
 	* Changes made to `deprecated`
 		* Deprecated property: `ribosomal_rna_28s_16s_ratio`
-	* Removed permissible value: `analyte_type_id`
 	* New property: `dna_integrity_number`
 	* New property: `ribosomal_rna_28s_18s_ratio`
 	* Removed property: `analyte_type_id`
@@ -217,19 +227,13 @@
 	* New property: `breslow_thickness_category`
 	* Changes made to `margin_status`
 		* New permissible value: `Indeterminate`
+    		* Deprecated value: `Indeterminant`
 	* Changes made to `timepoint_category`
 		* New permissible value: `After Study Registration`
-	* Removed property: `metastasis_at_diagnosis_site`
+    		* Deprecated value: `After Study Enrollment`
+   		* Deprecated value: `Prior to Study Enrollment`
 	* Removed property: `micropapillary_features`
-	* Removed property: `mitotic_count`
 	* Removed property: `papillary_renal_cell_type`
-	* Removed property: `pregnant_at_diagnosis`
-	* Removed property: `primary_disease`
-	* Changes made to `morphology`
-		* New permissible value: `8453/6`
-		* New permissible value: `9380/1`
-		* New permissible value: `9421/3`
-		* New permissible value: `9490/6`
 * Altered `treatment` Entity
 	* Removed property: `treatment_anatomic_site`
 	* Removed property: `treatment_arm`
@@ -244,6 +248,8 @@
 		* New permissible value: `Vagina`
 	* Changes made to `timepoint_category`
 		* New permissible value: `After Study Registration`
+    		* Deprecated value: `After Study Enrollment`
+   		* Deprecated value: `Prior to Study Enrollment`
 * Altered `somatic_mutation_calling_workflow` Entity
 	* Changes made to `workflow_type`
 		* New permissible value: `MuSiCal`
@@ -251,6 +257,8 @@
 * Altered `molecular_test` Entity
 	* Changes made to `timepoint_category`
 		* New permissible value: `After Study Registration`
+    		* Deprecated value: `After Study Enrollment`
+   		* Deprecated value: `Prior to Study Enrollment`
 * Altered `aggregated_somatic_mutation` Entity
 	* New property: `tmb`
 	* New property: `tmb_exonic`

--- a/docs/Data_Dictionary/Release_Notes/Data_Dictionary_Release_Notes.md
+++ b/docs/Data_Dictionary/Release_Notes/Data_Dictionary_Release_Notes.md
@@ -57,6 +57,10 @@
 		* New permissible value: `9421/3`
   	 	* New permissible value: `9478/3`
 		* New permissible value: `9490/6`
+  	* Removed property: `metastasis_at_diagnosis_site`
+  	* Removed property: `mitotic_count`
+  	* Removed property: `pregnant_at_diagnosis`
+  	* Removed property: `primary_disease`
 * Altered `family_history` Entity
   	* Changes made to `deprecated`
   	  	* Deprecated property: `relationship_gender`


### PR DESCRIPTION
- Family_history.relationship_sex_at_birth changed to `new`
- Family_history.relationship_gender changed to `deprecated`
- Diagnosis properties removed from pathology_detail
- `morphology` moved to diagnosis
- Follow_up.days_to_first_event removed from changelist
- Removed analyte.analyte_type_id from changelist
- `After Study Enrollment` and `Prior to Study Enrollment` added to timepoint_category as deprecated
- 9385/3 and 9478/3 added as new morphology values
- Removed 'deprecated' from follow_up entity
- Added 'indeterminant' as a deprecated value to margin_status