### PR TITLE
Add IDC Image Viewer docs

### DIFF
--- a/Data_Portal_UG.yml
+++ b/Data_Portal_UG.yml
@@ -22,6 +22,7 @@ nav:
       - Copy Number Segment: Data_Portal/Users_Guide/CNVtool.md
       - Correlation Plot: Data_Portal/Users_Guide/correlation.md
       - Gene Expression Clustering: Data_Portal/Users_Guide/gene_expression_clustering.md
+      - IDC Image Viewer: Data_Portal/Users_Guide/IDCViewer.md
       - Mutation Frequency: Data_Portal/Users_Guide/mutation_frequency.md
       - OncoMatrix: Data_Portal/Users_Guide/oncomatrix.md
       - ProteinPaint: Data_Portal/Users_Guide/proteinpaint_lollipop.md

--- a/docs/Data_Portal/Users_Guide/analysis_center.md
+++ b/docs/Data_Portal/Users_Guide/analysis_center.md
@@ -33,6 +33,7 @@ The 'Analysis Tools' section contains the tools available for specific analyses 
 * [Copy Number Segment](CNVtool.md)
 * [Correlation Plot](correlation.md)
 * [Gene Expression Clustering](gene_expression_clustering.md)
+* [IDC Image Viewer](IDCViewer.md)
 * [Mutation Frequency](mutation_frequency.md)
 * [OncoMatrix](oncomatrix.md)
 * [ProteinPaint](proteinpaint_lollipop.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - Copy Number Segment: Data_Portal/Users_Guide/CNVtool.md
       - Correlation Plot: Data_Portal/Users_Guide/correlation.md
       - Gene Expression Clustering: Data_Portal/Users_Guide/gene_expression_clustering.md
+      - IDC Image Viewer: Data_Portal/Users_Guide/IDCViewer.md
       - Mutation Frequency: Data_Portal/Users_Guide/mutation_frequency.md
       - OncoMatrix: Data_Portal/Users_Guide/oncomatrix.md
       - ProteinPaint: Data_Portal/Users_Guide/proteinpaint_lollipop.md


### PR DESCRIPTION
Draft for now until https://github.com/NCI-GDC/gdc-docs/pull/583 is merged. Will change base then.

This adds the IDC Image Viewer page to the docs.

Side Bar:
<img width="466" height="964" alt="Screenshot 2026-04-23 at 4 31 59 PM" src="https://github.com/user-attachments/assets/b1c77ede-00e7-4df3-808a-21ea93f5cde7" />


Analysis Center page:
<img width="1225" height="908" alt="Screenshot 2026-04-23 at 4 32 27 PM" src="https://github.com/user-attachments/assets/8fceb480-02fe-4b8f-a77e-c55adbdefd8b" />
