### PR TITLE
PEAR-2683 display treatment_type_administered values properly

### DIFF
--- a/docs/Data_Dictionary/viewer/dictionary-views.js
+++ b/docs/Data_Dictionary/viewer/dictionary-views.js
@@ -60,7 +60,7 @@
         );
       }
 
-      console.log("TableDefinitionsView Rendering!");
+      // console.log("TableDefinitionsView Rendering!");
     };
 
     TableDefinitionsView.prototype.renderDefinitionView = function (
@@ -68,7 +68,7 @@
     ) {
       var _tableDefinitionView = this;
 
-      console.log(currentDictionary);
+      // console.log(currentDictionary);
 
       _tableDefinitionView.renderHeader();
       _tableDefinitionView.renderSummaryTable();
@@ -263,9 +263,15 @@
               };
 
               for (var j = 0; j < propertyVal.length; j++) {
-                value.propertyValue.push(
-                  _getPropertyValueRecursive(propertyVal[j])
-                );
+                if (_.has(propertyVal[j], "enum")) {
+
+                  var enumValues = `Enumeration: <ul> <li> ${_getPropertyValueRecursive(propertyVal[j]).join("<li>")} </ul>`
+                  value.propertyValue.push(enumValues)
+
+                } else {
+                  value.propertyValue.push(
+                  _getPropertyValueRecursive(propertyVal[j]))
+                }
               }
               break;
           }
@@ -362,7 +368,7 @@
       // Make the excluded properties unique
       excludeProperties = _.uniq(excludeProperties);
 
-      console.log("Excluded Properties: ", excludeProperties);
+      // console.log("Excluded Properties: ", excludeProperties);
 
       var propertyIDs;
 
@@ -404,7 +410,7 @@
 
         // Ignore system properties for now...
         if (excludeProperties.indexOf(propertyName) >= 0) {
-          console.log("Skipping excluded property: " + propertyName);
+          // console.log("Skipping excluded property: " + propertyName);
           continue;
         }
 
@@ -1072,7 +1078,7 @@
         }
       }
 
-      console.log("TableEntityListView Rendering!");
+      // console.log("TableEntityListView Rendering!");
 
       _tableEntityListView._state = _DICTIONARY_CONSTANTS.VIEW_STATE.RENDERED;
       _tableEntityListView._callbackFn.call(
@@ -1395,7 +1401,7 @@
     // Public View API
     /////////////////////////////////////////////////////////
     _view.render = function () {
-      console.log("Rendering View!");
+      // console.log("Rendering View!");
 
       _view._d3ContainerSelection.html("");
 
@@ -1414,7 +1420,7 @@
     };
 
     _view.show = function () {
-      console.log("Showing!");
+      // console.log("Showing!");
 
       _view._isHidden = false;
       _view._state = _DICTIONARY_CONSTANTS.VIEW_STATE.ENTER;
@@ -1431,7 +1437,7 @@
     };
 
     _view.hide = function () {
-      console.log("Hiding!");
+      // console.log("Hiding!");
 
       _view._isHidden = true;
       _view._state = _DICTIONARY_CONSTANTS.VIEW_STATE.EXIT;

--- a/docs/Data_Dictionary/viewer/dictionary-views.js
+++ b/docs/Data_Dictionary/viewer/dictionary-views.js
@@ -261,12 +261,13 @@
 
               for (var j = 0; j < propertyVal.length; j++) {
                 // This code is potentially fragile. If we need to support more types of complex values nested under oneOf/anyOf, consider putting in a more robust fix.
-                if (_.has(propertyVal[j], "enum") && _.isArray(_getPropertyValueRecursive(propertyVal[j]))) {
+                var propertyValueRecursive = _getPropertyValueRecursive(propertyVal[j]);
+                if (_.has(propertyVal[j], "enum") && _.isArray(propertyValueRecursive)) {
                   var enumValuesAsHTMLList = _getPropertyValueRecursive(propertyVal[j]).map(enumValue => `<li>${enumValue}</li>`);
-                  value.propertyValue.push(`Enumeration: <ul> ${enumValuesAsHTMLList.join("")} </ul>`)
+                  value.propertyValue.push(`Enumeration: <ul> ${enumValuesAsHTMLList.join("")} </ul>`);
                 } else {
                   value.propertyValue.push(
-                  _getPropertyValueRecursive(propertyVal[j]))
+                  _getPropertyValueRecursive(propertyVal[j]));
                 }
               }
               break;

--- a/docs/Data_Dictionary/viewer/dictionary-views.js
+++ b/docs/Data_Dictionary/viewer/dictionary-views.js
@@ -263,7 +263,7 @@
                 // This code is potentially fragile. If we need to support more types of complex values nested under oneOf/anyOf, consider putting in a more robust fix.
                 var propertyValueRecursive = _getPropertyValueRecursive(propertyVal[j]);
                 if (_.has(propertyVal[j], "enum") && _.isArray(propertyValueRecursive)) {
-                  var enumValuesAsHTMLList = _getPropertyValueRecursive(propertyVal[j]).map(enumValue => `<li>${enumValue}</li>`);
+                  var enumValuesAsHTMLList = propertyValueRecursive.map(enumValue => `<li>${enumValue}</li>`);
                   value.propertyValue.push(`Enumeration: <ul> ${enumValuesAsHTMLList.join("")} </ul>`);
                 } else {
                   value.propertyValue.push(

--- a/docs/Data_Dictionary/viewer/dictionary-views.js
+++ b/docs/Data_Dictionary/viewer/dictionary-views.js
@@ -263,8 +263,8 @@
               };
 
               for (var j = 0; j < propertyVal.length; j++) {
-                if (_.has(propertyVal[j], "enum")) {
-
+                // This code is potentially fragile. If we need to support more types of complex values nested under oneOf/anyOf, consider putting in a more robust fix.
+                if (_.has(propertyVal[j], "enum") && _.isArray(_getPropertyValueRecursive(propertyVal[j]))) {
                   var enumValues = `Enumeration: <ul> <li> ${_getPropertyValueRecursive(propertyVal[j]).join("<li>")} </ul>`
                   value.propertyValue.push(enumValues)
 

--- a/docs/Data_Dictionary/viewer/dictionary-views.js
+++ b/docs/Data_Dictionary/viewer/dictionary-views.js
@@ -60,15 +60,12 @@
         );
       }
 
-      // console.log("TableDefinitionsView Rendering!");
     };
 
     TableDefinitionsView.prototype.renderDefinitionView = function (
       currentDictionary
     ) {
       var _tableDefinitionView = this;
-
-      // console.log(currentDictionary);
 
       _tableDefinitionView.renderHeader();
       _tableDefinitionView.renderSummaryTable();
@@ -368,8 +365,6 @@
       // Make the excluded properties unique
       excludeProperties = _.uniq(excludeProperties);
 
-      // console.log("Excluded Properties: ", excludeProperties);
-
       var propertyIDs;
 
       var requiredPartition = _.partition(
@@ -410,7 +405,6 @@
 
         // Ignore system properties for now...
         if (excludeProperties.indexOf(propertyName) >= 0) {
-          // console.log("Skipping excluded property: " + propertyName);
           continue;
         }
 
@@ -1078,8 +1072,6 @@
         }
       }
 
-      // console.log("TableEntityListView Rendering!");
-
       _tableEntityListView._state = _DICTIONARY_CONSTANTS.VIEW_STATE.RENDERED;
       _tableEntityListView._callbackFn.call(
         null,
@@ -1401,8 +1393,6 @@
     // Public View API
     /////////////////////////////////////////////////////////
     _view.render = function () {
-      // console.log("Rendering View!");
-
       _view._d3ContainerSelection.html("");
 
       // Show the controls before rendering
@@ -1420,8 +1410,6 @@
     };
 
     _view.show = function () {
-      // console.log("Showing!");
-
       _view._isHidden = false;
       _view._state = _DICTIONARY_CONSTANTS.VIEW_STATE.ENTER;
       _view._d3ContainerSelection
@@ -1437,8 +1425,6 @@
     };
 
     _view.hide = function () {
-      // console.log("Hiding!");
-
       _view._isHidden = true;
       _view._state = _DICTIONARY_CONSTANTS.VIEW_STATE.EXIT;
       _view._d3ContainerSelection

--- a/docs/Data_Dictionary/viewer/dictionary-views.js
+++ b/docs/Data_Dictionary/viewer/dictionary-views.js
@@ -262,8 +262,8 @@
               for (var j = 0; j < propertyVal.length; j++) {
                 // This code is potentially fragile. If we need to support more types of complex values nested under oneOf/anyOf, consider putting in a more robust fix.
                 if (_.has(propertyVal[j], "enum") && _.isArray(_getPropertyValueRecursive(propertyVal[j]))) {
-                  var enumValues = `Enumeration: <ul> <li> ${_getPropertyValueRecursive(propertyVal[j]).join("<li>")} </ul>`
-                  value.propertyValue.push(enumValues)
+                  var enumValuesAsHTMLList = _getPropertyValueRecursive(propertyVal[j]).map(enumValue => `<li>${enumValue}</li>`);
+                  value.propertyValue.push(`Enumeration: <ul> ${enumValuesAsHTMLList.join("")} </ul>`)
                 } else {
                   value.propertyValue.push(
                   _getPropertyValueRecursive(propertyVal[j]))

--- a/docs/Data_Dictionary/viewer/dictionary-views.js
+++ b/docs/Data_Dictionary/viewer/dictionary-views.js
@@ -266,8 +266,7 @@
                   var enumValuesAsHTMLList = propertyValueRecursive.map(enumValue => `<li>${enumValue}</li>`);
                   value.propertyValue.push(`Enumeration: <ul> ${enumValuesAsHTMLList.join("")} </ul>`);
                 } else {
-                  value.propertyValue.push(
-                  _getPropertyValueRecursive(propertyVal[j]));
+                  value.propertyValue.push(propertyValueRecursive);
                 }
               }
               break;

--- a/docs/Data_Dictionary/viewer/dictionary-views.js
+++ b/docs/Data_Dictionary/viewer/dictionary-views.js
@@ -264,7 +264,6 @@
                 if (_.has(propertyVal[j], "enum") && _.isArray(_getPropertyValueRecursive(propertyVal[j]))) {
                   var enumValues = `Enumeration: <ul> <li> ${_getPropertyValueRecursive(propertyVal[j]).join("<li>")} </ul>`
                   value.propertyValue.push(enumValues)
-
                 } else {
                   value.propertyValue.push(
                   _getPropertyValueRecursive(propertyVal[j]))


### PR DESCRIPTION
- display enums nested under "oneOf"s properly with "Enumeration:" and nested bullets
- removes a bunch of preexisting console.logs

<img width="1582" height="1038" alt="Screenshot 2026-05-14 at 10 31 15 PM" src="https://github.com/user-attachments/assets/bddeb2f8-45b8-447e-9066-131f9b530cae" />
