### PR TITLE
DOC-525 fixes broken links on landing page

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -11,9 +11,9 @@
     ('For Researchers', '#1db888', '/images/hp-icons-researcher.png', [
         ('Understand the Data in the GDC', '/Data/Introduction/'),
         ('Access Controlled Data in the GDC', '/Data/Data_Security/Data_Security/'),
-        ('Explore Data in the GDC', '/Data_Portal_V1/Users_Guide/Exploration/'),
+        ('Build Custom Cohorts in the GDC', '/Data_Portal/Users_Guide/cohort_builder/'),
         ('Download Files in the GDC', '/Data_Transfer_Tool/Users_Guide/Preparing_for_Data_Download_and_Upload/'),
-        ('Analyze Data in the GDC', '/Data_Portal_V1/Users_Guide/Custom_Set_Analysis/')
+        ('Analyze Data in the GDC', '/Data_Portal/Users_Guide/analysis_center/')
     ]),
     ('For Data Submitters', '#676bc0', '/images/hp-icons-submitter.png', [
         ('View the GDC Data Dictionary', '/Data_Dictionary/viewer/'),


### PR DESCRIPTION
Fixes two broken links on the landing page.

<img width="449" height="356" alt="Screenshot 2026-05-25 at 5 41 40 PM" src="https://github.com/user-attachments/assets/eb1b935c-6983-476f-843d-003f2c8b77a1" />
